### PR TITLE
Keep chatter away from API

### DIFF
--- a/common.lua
+++ b/common.lua
@@ -137,12 +137,6 @@ end
 jumpdrive.execute_jump = function(pos, player)
 
 	local meta = minetest.get_meta(pos)
-	local playername = meta:get_string("owner")
-
-	if player ~= nil then
-		playername = player:get_player_name()
-	end
-
 
 	local radius = jumpdrive.get_radius(pos)
 	local targetPos = jumpdrive.get_meta_pos(pos)
@@ -158,7 +152,6 @@ jumpdrive.execute_jump = function(pos, player)
 
 	local success, msg = jumpdrive.simulate_jump(pos, player, false)
 	if not success then
-		minetest.chat_send_player(playername, msg)
 		return false, msg
 	end
 
@@ -179,11 +172,8 @@ jumpdrive.execute_jump = function(pos, player)
 
 	local t1 = minetest.get_us_time()
 	local time_micros = t1 - t0
-	local time_millis = math.floor(time_micros / 1000)
 
 	minetest.log("action", "[jumpdrive] jump took " .. time_micros .. " us")
-	minetest.chat_send_player(playername, "Jump executed in " .. time_millis .. " ms")
-
 
 	-- show animation in source
 	minetest.add_particlespawner({

--- a/engine.lua
+++ b/engine.lua
@@ -171,7 +171,13 @@ minetest.register_node("jumpdrive:engine", {
 		jumpdrive.update_formspec(meta, pos)
 
 		if fields.jump then
-			jumpdrive.execute_jump(pos, sender)
+			local success, msg = jumpdrive.execute_jump(pos, sender)
+			if success then
+				local time_millis = math.floor(msg / 1000)
+				minetest.chat_send_player(sender:get_player_name(), "Jump executed in " .. time_millis .. " ms")
+			else
+				minetest.chat_send_player(sender:get_player_name(), msg)
+			end
 		end
 
 		if fields.show then

--- a/fleet_controller.lua
+++ b/fleet_controller.lua
@@ -192,9 +192,14 @@ minetest.register_node("jumpdrive:fleet_controller", {
 		if jump_list and jump_index and #jump_list >= jump_index then
 
 			local is_last = #jump_list == jump_index
-
 			local node_pos = jump_list[jump_index]
 			local success, msg = jumpdrive.execute_jump(node_pos)
+
+			local playername = meta:get_string("owner")
+			if not playername then
+				local node_meta = minetest.get_meta(node_pos)
+				playername = node_meta:get_string("owner")
+			end
 
 			if success then
 				-- at this point if it is the last engine the metadata does not exist anymore in the current location
@@ -207,10 +212,17 @@ minetest.register_node("jumpdrive:fleet_controller", {
 					local timer = minetest.get_node_timer(pos)
 					timer:start(2.0)
 				end
+				if playername then
+					local time_millis = math.floor(msg / 1000)
+					minetest.chat_send_player(playername, "Jump executed in " .. time_millis .. " ms")
+				end
 			else
 				meta:set_int("active", 0)
 				update_formspec(meta, pos)
 				meta:set_string("infotext", "Engine ".. minetest.pos_to_string(node_pos) .. " failed with: " .. msg)
+				if playername then
+					minetest.chat_send_player(playername, msg)
+				end
 			end
 		else
 			meta:set_int("active", 0)


### PR DESCRIPTION
This should fix https://github.com/mt-mods/jumpdrive/issues/63

This could be made cleaner too, currently it is to also support fleet controllers without owner:
https://github.com/mt-mods/jumpdrive/compare/master...S-S-X:chatter?expand=1#diff-0ba6fcb65a44d6ee9b815d4d82a68ea1R198-R203

New fleet controllers will have owner after https://github.com/mt-mods/jumpdrive/pull/62 is merged.