### PR TITLE
JD digiline channel and cheaper "set" command

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -47,6 +47,8 @@ minetest.register_node("jumpdrive:engine", {
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("owner", placer:get_player_name() or "")
+		-- default digiline channel
+		meta:set_string("channel", "jumpdrive")
 	end,
 
 	on_construct = function(pos)
@@ -144,6 +146,12 @@ minetest.register_node("jumpdrive:engine", {
 
 		if fields.write_book then
 			jumpdrive.write_to_book(pos, sender)
+			return
+		end
+
+		if fields.set_digiline_channel and fields.digiline_channel then
+			meta:set_string("channel", fields.digiline_channel)
+			jumpdrive.update_formspec(meta, pos)
 			return
 		end
 

--- a/formspec.lua
+++ b/formspec.lua
@@ -29,7 +29,8 @@ jumpdrive.update_formspec = function(meta, pos)
 		"list[current_player;main;0,".. 4.5+inv_offset .. ";8,4;]" ..
 
 		-- digiline channel
-		"field[4.3," .. 9.02+inv_offset ..";3.2,1;digiline_channel;Digiline channel;" .. (meta:get_string("channel") or "") .. "]" ..
+		"field[4.3," .. 9.02+inv_offset ..";3.2,1;digiline_channel;Digiline channel;" ..
+		(meta:get_string("channel") or "") .. "]" ..
 		"button_exit[7," .. 8.7+inv_offset .. ";1,1;set_digiline_channel;Set]" ..
 
 		-- listring stuff

--- a/formspec.lua
+++ b/formspec.lua
@@ -14,19 +14,23 @@ jumpdrive.update_formspec = function(meta, pos)
 		"field[4.3,0.5;2,1;z;Z;" .. meta:get_int("z") .. "]" ..
 		"field[6.3,0.5;2,1;radius;Radius;" .. meta:get_int("radius") .. "]" ..
 
-		"button_exit[0,1.5;2,1;jump;Jump]" ..
-		"button_exit[2,1.5;2,1;show;Show]" ..
-		"button_exit[4,1.5;2,1;save;Save]" ..
-		"button[6,1.5;2,1;reset;Reset]" ..
+		"button_exit[0,1;2,1;jump;Jump]" ..
+		"button_exit[2,1;2,1;show;Show]" ..
+		"button_exit[4,1;2,1;save;Save]" ..
+		"button[6,1;2,1;reset;Reset]" ..
 
-		"button[0,2.5;4,1;write_book;Write to book]" ..
-		"button[4,2.5;4,1;read_book;Read from book]" ..
+		"button[0,2;4,1;write_book;Write to book]" ..
+		"button[4,2;4,1;read_book;Read from book]" ..
 
 		-- main inventory for fuel and books
-		"list[context;main;0,3.75;8,1;]" ..
+		"list[context;main;0,3.25;8,1;]" ..
 
 		-- player inventory
-		"list[current_player;main;0,".. 5.5+inv_offset .. ";8,4;]" ..
+		"list[current_player;main;0,".. 4.5+inv_offset .. ";8,4;]" ..
+
+		-- digiline channel
+		"field[4.3," .. 9.02+inv_offset ..";3.2,1;digiline_channel;Digiline channel;" .. (meta:get_string("channel") or "") .. "]" ..
+		"button_exit[7," .. 8.7+inv_offset .. ";1,1;set_digiline_channel;Set]" ..
 
 		-- listring stuff
 		"listring[context;main]" ..
@@ -35,8 +39,8 @@ jumpdrive.update_formspec = function(meta, pos)
 	if has_technic then
 		formspec = formspec ..
 			-- technic upgrades
-			"label[1,5.2;Upgrades]" ..
-			"list[context;upgrade;4,5;4,1;]"
+			"label[3,4.7;Upgrades]" ..
+			"list[context;upgrade;4,4.5;4,1;]"
 	end
 
 	meta:set_string("formspec", formspec)


### PR DESCRIPTION
This PR adds following:
* Similar set command that fleet controller uses but of course also adds radius setting.
* "set" command is fully backward compatible.
* Digiline channel field to formspec, like one in fleet controller formspec.
* this is also fully backward compatible until set first time.
