### PR TITLE
Add compat for technic switching station cache

### DIFF
--- a/compat/compat.lua
+++ b/compat/compat.lua
@@ -19,6 +19,7 @@ dofile(MP.."/compat/elevator.lua")
 dofile(MP.."/compat/signs.lua")
 dofile(MP.."/compat/itemframes.lua")
 dofile(MP.."/compat/anchor.lua")
+dofile(MP.."/compat/switching_station.lua")
 dofile(MP.."/compat/telemosaic.lua")
 dofile(MP.."/compat/beds.lua")
 dofile(MP.."/compat/ropes.lua")
@@ -38,6 +39,8 @@ jumpdrive.node_compat = function(name, source_pos, target_pos, source_pos1, sour
 
 	elseif has_technic_mod and name == "technic:admin_anchor" then
 		jumpdrive.anchor_compat(source_pos, target_pos)
+	elseif has_technic_mod and technic.networks and name == "technic:switching_station" then
+		jumpdrive.switching_station_compat(source_pos, target_pos)
 
 	elseif has_pipeworks_mod and string.find(name, "^pipeworks:teleport_tube") then
 		jumpdrive.teleporttube_compat(source_pos, target_pos)

--- a/compat/switching_station.lua
+++ b/compat/switching_station.lua
@@ -1,0 +1,7 @@
+jumpdrive.switching_station_compat = function(source_pos, target_pos)
+	if not technic.networks then return end
+
+	-- clear network cache for both positions
+	technic.networks[minetest.hash_node_position({ x = source_pos.x, y = source_pos.y-1, z = source_pos.z })] = nil
+	technic.networks[minetest.hash_node_position({ x = target_pos.x, y = target_pos.y-1, z = target_pos.z })] = nil
+end


### PR DESCRIPTION
The technic mod uses two caches that are problematic when parts of the network are moved with a jumpdrive: one for the network that is associated with the switching station, and one where each cable is associcated with a network.

These caches need to be invalidated when the jumpdrive modifies the network.

Steps to reproduce the bug:
1. Start with a network at location X
2. Jump to location Y
3. Modify the network at the new location (e. g. add a battery)
4. Jump back to location X

The switching station will reuse the old, now outdated entry from the cache and ignore the changes to the network.

This PR clears the *network cache* at the source and target positions, and should fix the bug when the whole network is teleported.

To cover cases where only a part of the network is teleported, this needs more work:
* If a switching station is on the part of the network that is not moved, it's cache entry must also be invalidated.
* Cable entries for the whole network should probably also be invalidated.

I will probably not get back to this issue soon, so please feel free to take over.