### PR TITLE
Technic compatibility with fully contained network move capability

### DIFF
--- a/compat/compat.lua
+++ b/compat/compat.lua
@@ -19,6 +19,7 @@ dofile(MP.."/compat/elevator.lua")
 dofile(MP.."/compat/signs.lua")
 dofile(MP.."/compat/itemframes.lua")
 dofile(MP.."/compat/anchor.lua")
+dofile(MP.."/compat/technic_networks.lua")
 dofile(MP.."/compat/telemosaic.lua")
 dofile(MP.."/compat/beds.lua")
 dofile(MP.."/compat/ropes.lua")
@@ -82,6 +83,10 @@ jumpdrive.target_region_compat = function(source_pos1, source_pos2, target_pos1,
 
 	if has_areas_mod then
 		jumpdrive.areas_compat(source_pos1, source_pos2, delta_vector)
+	end
+
+	if has_technic_mod then
+		jumpdrive.technic_network_compat(source_pos1, source_pos2, target_pos1, delta_vector)
 	end
 
 	-- async compat functions below here

--- a/compat/technic_networks.lua
+++ b/compat/technic_networks.lua
@@ -1,0 +1,98 @@
+
+local vecadd = vector.add
+local poshash = minetest.hash_node_position
+local cables = technic.cables
+local machines = technic.machine_tiers
+
+-- Function to move technic network to another position
+local network_node_arrays = {"PR_nodes","BA_nodes","RE_nodes"}
+local function move_network(net, delta)
+	for _,tblname in ipairs(network_node_arrays) do
+		local tbl = network[tblname]
+		for i=#tbl,1,-1 do
+			tbl[i] = vecadd(tbl[i], delta)
+		end
+	end
+	local new_net_id = vecadd(technic.network2pos(net.id), delta)
+	local all_nodes = net.all_nodes
+	for old_node_id, old_pos in pairs(all_nodes) do
+		local new_pos = vecadd(old_pos, delta)
+		local node_id = poshash(new_pos)
+		cables[old_node_id] = nil
+		new_all_nodes[node_id] = new_pos
+		cables[node_id] = new_net_id
+	end
+	net.all_nodes = new_all_nodes
+end
+
+local function add_edge_cable_net(pos, size, delta, t)
+	-- Find connected positions outside edge of box from given position
+	-- NOTE: At source position firt found would be enough but not at target
+	local x = pos.x == 0 and -1 or (pos.x == size.x and 1)
+	local y = pos.y == 0 and -1 or (pos.y == size.y and 1)
+	local z = pos.z == 0 and -1 or (pos.z == size.z and 1)
+	if x then
+		local v = vecadd(vecadd(pos, {x=x,y=0,z=0}),delta)
+		local net_id = cables[poshash(v)]
+		if net_id then t[net_id] = true end
+	end
+	if y then
+		local v = vecadd(vecadd(pos, {x=0,y=y,z=0}),delta)
+		local net_id = cables[poshash(v)]
+		if net_id then t[net_id] = true end
+	end
+	if z then
+		local v = vecadd(vecadd(pos, {x=0,y=0,z=z}),delta)
+		local net_id = cables[poshash(v)]
+		if net_id then t[net_id] = true end
+	end
+end
+
+jumpdrive.technic_network_compat = function(source_pos1, source_pos2, target_pos1, delta_vector)
+	-- Check for technic mod compatibility
+	if not technic.remove_network or not technic.networks then return end
+
+	-- search results
+	local jump_networks = {} -- jumped fully contained networks
+	local edge_networks = {} -- networks crossing jumped area edge
+
+	-- search for networks in area
+	local size = vector.apply(vector.subtract(source_pos1, source_pos2),math.abs)
+	for x=0,size.x do
+		for y=0,size.y do
+			for z=0,size.z do
+				local local_pos = {x=x,y=y,z=z}
+				local src_pos = vecadd(source_pos1, local_pos)
+				local net_id = cables[poshash(src_pos)]
+				if net_id then
+					-- Add to (dirty) jumped networks
+					jump_networks[net_id] = true
+					if x==0 or x==size.x or y==0 or y==size.y or z==0 or z==size.z then
+						-- Candidate for edge network, check neighbors across border
+						add_edge_cable_net(local_pos, size, source_pos1, edge_networks)
+						add_edge_cable_net(local_pos, size, target_pos1, edge_networks)
+					end
+				elseif x==0 or x==size.x or y==0 or y==size.y or z==0 or z==size.z then
+					-- Check for unconnected nodes that might connect to network at target location
+					local name = minetest.get_node(src_pos).name
+					if machines[name] or technic.get_cable_tier(name) then
+						add_edge_cable_net(local_pos, size, target_pos1, edge_networks)
+					end
+				end
+			end
+		end
+	end
+	for net_id, _ in pairs(edge_networks) do
+		-- Remove edge networks to create contained networks list
+		jump_networks[net_id] = nil
+		-- And clean up network crossing jumped area edges
+		technic.remove_network(net_id)
+	end
+	for net_id, _ in pairs(jump_networks) do
+		-- Move fully contained networks with jumpdrive
+		local net = technic.networks[net_id]
+		if net then
+			move_network(net, delta_vector)
+		end
+	end
+end

--- a/compat/technic_networks.lua
+++ b/compat/technic_networks.lua
@@ -1,6 +1,7 @@
 
 local vecadd = vector.add
 local poshash = minetest.hash_node_position
+local get_node = minetest.get_node
 local cables = technic.cables
 local machines = technic.machine_tiers
 
@@ -8,26 +9,35 @@ local machines = technic.machine_tiers
 local network_node_arrays = {"PR_nodes","BA_nodes","RE_nodes"}
 local function move_network(net, delta)
 	for _,tblname in ipairs(network_node_arrays) do
-		local tbl = network[tblname]
+		local tbl = net[tblname]
 		for i=#tbl,1,-1 do
 			tbl[i] = vecadd(tbl[i], delta)
 		end
 	end
-	local new_net_id = vecadd(technic.network2pos(net.id), delta)
+	local new_net_id = poshash(vecadd(technic.network2pos(net.id), delta))
+	local new_all_nodes = {}
 	local all_nodes = net.all_nodes
 	for old_node_id, old_pos in pairs(all_nodes) do
 		local new_pos = vecadd(old_pos, delta)
 		local node_id = poshash(new_pos)
 		cables[old_node_id] = nil
-		new_all_nodes[node_id] = new_pos
 		cables[node_id] = new_net_id
+		new_all_nodes[node_id] = new_pos
 	end
 	net.all_nodes = new_all_nodes
 end
 
+local function vecadd2(a, b, c)
+	return {
+		x = a.x + b.x + c.x,
+		y = a.y + b.y + c.y,
+		z = a.z + b.z + c.z,
+	}
+end
+
 local function add_edge_cable_net(pos, size, delta, t)
 	-- Find connected positions outside edge of box from given position
-	-- NOTE: At source position firt found would be enough but not at target
+	-- NOTE: At source position first found would be enough but not at target
 	local x = pos.x == 0 and -1 or (pos.x == size.x and 1)
 	local y = pos.y == 0 and -1 or (pos.y == size.y and 1)
 	local z = pos.z == 0 and -1 or (pos.z == size.z and 1)
@@ -46,6 +56,7 @@ local function add_edge_cable_net(pos, size, delta, t)
 		local net_id = cables[poshash(v)]
 		if net_id then t[net_id] = true end
 	end
+	return x, y, z
 end
 
 jumpdrive.technic_network_compat = function(source_pos1, source_pos2, target_pos1, delta_vector)
@@ -65,17 +76,28 @@ jumpdrive.technic_network_compat = function(source_pos1, source_pos2, target_pos
 				local src_pos = vecadd(source_pos1, local_pos)
 				local net_id = cables[poshash(src_pos)]
 				if net_id then
-					-- Add to (dirty) jumped networks
+					-- Add to (dirty) jumped fully contained networks
 					jump_networks[net_id] = true
-					if x==0 or x==size.x or y==0 or y==size.y or z==0 or z==size.z then
-						-- Candidate for edge network, check neighbors across border
-						add_edge_cable_net(local_pos, size, source_pos1, edge_networks)
-						add_edge_cable_net(local_pos, size, target_pos1, edge_networks)
-					end
-				elseif x==0 or x==size.x or y==0 or y==size.y or z==0 or z==size.z then
-					-- Check for unconnected nodes that might connect to network at target location
-					local name = minetest.get_node(src_pos).name
-					if machines[name] or technic.get_cable_tier(name) then
+				end
+				if x==0 or x==size.x or y==0 or y==size.y or z==0 or z==size.z then
+					-- Candidate for border crossing network, check neighbors across border
+					if net_id then
+						-- Inside network is active, check outside for active and inactive
+						local x, y, z = add_edge_cable_net(local_pos, size, source_pos1, edge_networks)
+						if x then
+							local name = get_node(vecadd2(local_pos, target_pos1, {x=x,y=0,z=0})).name
+							if machines[name] or technic.get_cable_tier(name) then edge_networks[net_id] = true end
+						end
+						if y then
+							local name = get_node(vecadd2(local_pos, target_pos1, {x=0,y=y,z=0})).name
+							if machines[name] or technic.get_cable_tier(name) then edge_networks[net_id] = true end
+						end
+						if z then
+							local name = get_node(vecadd2(local_pos, target_pos1, {x=0,y=0,z=z})).name
+							if machines[name] or technic.get_cable_tier(name) then edge_networks[net_id] = true end
+						end
+					else
+						-- Inside is inactive, check outside for active
 						add_edge_cable_net(local_pos, size, target_pos1, edge_networks)
 					end
 				end


### PR DESCRIPTION
Currently just for single engine ships. If networks are fully contained this should be a lot faster and cheaper compared to full network rebuilds.
Also if someone who knows math can make it better then.. well, it probably will be better.

@OgelGames @BuckarooBanzay do you see problems here (other than nested loops, those never look pretty)

This supersedes #78 that I investigated a bit and realized that it wont work.

Testing with R7 contained network moving network with this takes about 20% of rebuilding network.
This is pretty much required to make new networks jumpable because those will not lose cache that easily.