### PR TITLE
Tweak visuals and limit jump simulations when visuals are enabled

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -251,25 +251,14 @@ minetest.register_node("jumpdrive:engine", {
 		end
 	end,
 
-	on_punch = function(pos, _, player)
-		if not has_vizlib then
-			-- no visualization lib
-			return
-		end
+	on_punch = has_vizlib and function(pos, _, player)
 		if not player or player:get_wielded_item():get_name() ~= "" then
-			-- non-empty hand
+			-- Only show jump area when using an empty hand
 			return
 		end
-		if minetest.is_protected(pos, player:get_player_name()) then
-			-- non-owner
-			return
-		end
-
-		local meta = minetest.get_meta(pos);
-		local radius = meta:get_int("radius")
-
-		vizlib.draw_cube(pos, radius + 0.5, { color = "#00ff00" })
-	end
+		local radius = minetest.get_meta(pos):get_int("radius")
+		vizlib.draw_cube(pos, radius + 0.5, { color = "#00ff00", player = player })
+	end or nil,
 })
 
 if minetest.get_modpath("technic") then

--- a/jump.lua
+++ b/jump.lua
@@ -9,6 +9,11 @@ jumpdrive.simulate_jump = function(pos, player, show_marker)
 	end
 
 	local meta = minetest.get_meta(pos)
+
+	if show_marker and has_vizlib and os.time() < meta:get_int("simulation_expiry") then
+		return false, "Error: simulation is still active! please wait before simulating again"
+	end
+
 	local radius = jumpdrive.get_radius(pos)
 	local distance = vector.distance(pos, targetPos)
 
@@ -41,6 +46,8 @@ jumpdrive.simulate_jump = function(pos, player, show_marker)
 	if show_marker and has_vizlib then
 		vizlib.draw_cube(targetPos, radius + 0.5, { color = "#ff0000" })
 		vizlib.draw_cube(pos, radius + 0.5, { color = "#00ff00" })
+		local shape = vizlib.draw_point(targetPos, { color = "#0000ff" })
+		meta:set_int("simulation_expiry", shape.expiry)
 	end
 
 	local msg = nil


### PR DESCRIPTION
This PR does a few small things:
- Adds a blue "point" at the target location of the jumpdrive when simulating a jump
- Prevents multiple simulations at the same time when visuals are enabled, to limit the particles being sent to other clients
- Changes the punch-to-show visual to only be sent to the punching player

The blue "point" looks like this, it's a single particle spawner instead of the 12 required for a 1x1x1 cube.
![image](https://github.com/mt-mods/jumpdrive/assets/48543043/5f8bf357-55c9-4f30-9890-bae6f7aa6abc)
