### PR TITLE
Fix formspec for technic upgrade slots in MineClone

### DIFF
--- a/fleet/fleet_formspec.lua
+++ b/fleet/fleet_formspec.lua
@@ -13,8 +13,8 @@ if minetest.get_modpath("mcl_formspec") then
    player_inv_fs = ""..
       "list[current_player;main;0,4.9;9,3;9]"..
       mcl_formspec.get_itemslot_bg(0,4.9,9,3)..
-      "list[current_player;main;0,8.14;9,1;]"..
-      mcl_formspec.get_itemslot_bg(0,8.14,9,1)
+      "list[current_player;main;0,8.05;9,1;]"..
+      mcl_formspec.get_itemslot_bg(0,8.05,9,1)
    listring_fs = "listring[current_player;main]"
 end
 

--- a/formspec.lua
+++ b/formspec.lua
@@ -14,10 +14,10 @@ if minetest.get_modpath("mcl_formspec") then
    inv_width = 9
    mcl_fs = mcl_formspec.get_itemslot_bg(0,3.25,8,1)
    player_inv_fs = ""..
-      "list[current_player;main;0,4.4;9,3;9]"..
-      mcl_formspec.get_itemslot_bg(0,4.4,9,3)..
-      "list[current_player;main;0,7.64;9,1;]"..
-      mcl_formspec.get_itemslot_bg(0,7.64,9,1)
+      "list[current_player;main;0,5.6;9,3;9]"..
+      mcl_formspec.get_itemslot_bg(0,5.6,9,3)..
+      "list[current_player;main;0,8.74;9,1;]"..
+      mcl_formspec.get_itemslot_bg(0,8.74,9,1)
    if has_technic then
       mcl_fs = mcl_fs..
 	 mcl_formspec.get_itemslot_bg(4,4.5,4,1)


### PR DESCRIPTION
when technic is in MineClone the upgrade slots were mixed with the player inventory