### PR TITLE
catch nil in compat/telemosaic.lua

### DIFF
--- a/compat/telemosaic.lua
+++ b/compat/telemosaic.lua
@@ -94,6 +94,10 @@ jumpdrive.telemosaic_compat = function(source_pos, target_pos, source_pos1, sour
 	local remote_meta = core.get_meta(remote_pos)
 	local remote_dest, uses_hash = unpack_pos(remote_meta:get_string('telemosaic:dest'))
 
+	if not remote_dest then
+		return -- no destination set
+	end
+	
 	if core.pos_to_string(remote_dest) == core.pos_to_string(source_pos) then
 		-- remote beacon points to this beacon, update link
 		core.log("action", "[jumpdrive] rewiring telemosaic at " ..

--- a/compat/telemosaic.lua
+++ b/compat/telemosaic.lua
@@ -97,7 +97,7 @@ jumpdrive.telemosaic_compat = function(source_pos, target_pos, source_pos1, sour
 	if not remote_dest then
 		return -- no destination set
 	end
-	
+
 	if core.pos_to_string(remote_dest) == core.pos_to_string(source_pos) then
 		-- remote beacon points to this beacon, update link
 		core.log("action", "[jumpdrive] rewiring telemosaic at " ..


### PR DESCRIPTION
Have not tested.

reaction to crash:
```
2026-02-03 20:21:51: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod 'mesecons' in callback environment_Step(): /usr/local/share/luanti/builtin/common/misc_helpers.lua:478: attempt to index local 'pos' (a nil value)
2026-02-03 20:21:51: ERROR[Main]: stack traceback:
2026-02-03 20:21:51: ERROR[Main]: 	/usr/local/share/luanti/builtin/common/misc_helpers.lua:478: in function 'pos_to_string'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/jumpdrive/compat/telemosaic.lua:97: in function 'telemosaic_compat'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/jumpdrive/compat/compat.lua:73: in function 'node_compat'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/jumpdrive/move/move_metadata.lua:29: in function 'move_metadata'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/jumpdrive/move/move.lua:40: in function 'old_jumpdrive_move'
2026-02-03 20:21:51: ERROR[Main]: 	...rld/worldmods/find_nodes_in_area_cache/register_mods.lua:24: in function 'move'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/jumpdrive/jump.lua:157: in function 'execute_jump'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/jumpdrive/digiline.lua:92: in function 'action'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/digicontrol/override.lua:45: in function 'f'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/monitoring/metrictypes/counter.lua:44: in function 'transmit'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/digicontrol/override.lua:78: in function 'f'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/monitoring/metrictypes/counter.lua:44: in function 'receptor_send'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/mooncontroller/controller.lua:714: in function </data/world/worldmods/mooncontroller/controller.lua:708>
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/mesecons/mesecons/actionqueue.lua:131: in function 'f'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/monitoring/metrictypes/counter.lua:44: in function 'old_execute'
2026-02-03 20:21:51: ERROR[Main]: 	...ld/worldmods/mesecons_debug/overrides/mesecons_queue.lua:27: in function 'execute'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/mesecons/mesecons/actionqueue.lua:121: in function 'func'
2026-02-03 20:21:51: ERROR[Main]: 	.../local/share/luanti/builtin/profiler/instrumentation.lua:111: in function 'globalstep'
2026-02-03 20:21:51: ERROR[Main]: 	/data/world/worldmods/monitoring/builtin/globalstep.lua:73: in function </data/world/worldmods/monitoring/builtin/globalstep.lua:55>
2026-02-03 20:21:51: ERROR[Main]: 	/usr/local/share/luanti/builtin/common/register.lua:26: in function </usr/local/share/luanti/builtin/common/register.lua:12>
```